### PR TITLE
Use spawn instead of threadid

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JMPReader"
 uuid = "d9f7e686-cf87-4d12-8d7a-0e9b8c9fba29"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Jaakko Ruohio <jaakkor2@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Fix #24 following example in https://julialang.org/blog/2023/07/PSA-dont-use-threadid/ .

For a big file (23499173×139 DataFrame) I get with `--threads=auto`
```
@time df=readjmp("bigfile.jmp");
```
```
 17.006515 seconds (6.57 k allocations: 67.254 GiB, 29.61% gc time) # 1.10.8
 10.539399 seconds (5.67 k allocations: 63.813 GiB, 15.40% gc time, 136 lock conflicts) # 1.12.0-DEV.2030 (2025-02-17)
```