### PR TITLE
Rename keywords include_columns and exclude_columns to select and drop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "JMPReader"
 uuid = "d9f7e686-cf87-4d12-8d7a-0e9b8c9fba29"
-version = "0.1.14"
 authors = ["Jaakko Ruohio <jaakkor2@gmail.com>"]
+version = "0.1.15"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DeprecateKeywords = "83f0f1bf-2a81-4f2a-8178-033dcab3e60b"
 LibDeflate = "9255714d-24a7-4b30-8ea3-d46a97f7e13b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
@@ -17,6 +18,7 @@ CodecZlib = "0.7"
 ColorTypes = "0.11.4, 0.12"
 DataFrames = "1"
 Dates = "1.6"
+DeprecateKeywords = "0.4"
 LibDeflate = "0.4"
 Mmap = "1"
 Printf = "1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,9 +31,9 @@ to read file `fn` and get the data as a Julia `DataFrame`.  All columns are incl
 
 ## Choosing columns
 
-Two keyword arguments are available, `include_columns` and `exclude_columns`
+Two keyword arguments are available, `select` and `drop`
 ```
-df = readjmp(fn, include_columns=[2, "date", r"^char"], exclude_columns=[r"varia"])
+df = readjmp(fn, select=[2, "date", r"^char"], drop=[r"varia"])
 ``` 
 returns the second column `floats`, a column named `date`, columns that start with `char`,
 but excluding columns whose name contain a string `varia`.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -72,13 +72,13 @@ function rstripnull!(s::StringVector)
     nothing
 end
 
-function filter_columns(names, include_columns, exclude_columns)
+function filter_columns(names, select, drop)
     cols = 1:length(names)
-    if !isnothing(include_columns)
-        cols = intersect(cols, filter_names(names, include_columns))
+    if !isnothing(select)
+        cols = intersect(cols, filter_names(names, select))
     end
-    if !isnothing(exclude_columns)
-        cols = setdiff(cols, filter_names(names, exclude_columns))
+    if !isnothing(drop)
+        cols = setdiff(cols, filter_names(names, drop))
     end
     cols = sort(cols)
     return cols

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,9 +75,9 @@ end
     @test JMPReader.filter_columns(names, ["foo_x", :baz, r"^bar", 3, 1:2], [4, r"x$"]) == [1,3,6,7]
 end
 
-@testset "include/exclude columns" begin
-    @test names(readjmp("time.jmp", include_columns = [1,3:2:5,"ddMonyyyy h:m"])) == ["m-d-y h:m", "d-m-y h:m", "y-m-d h:m", "ddMonyyyy h:m"]
-    @test names(readjmp("time.jmp", exclude_columns = [r"d"])) == ["h:m:s", "h:m", "Locale Date Time h:m", "Locale Date Time h:m:s"]
+@testset "select/drop columns" begin
+    @test names(readjmp("time.jmp", select = [1,3:2:5,"ddMonyyyy h:m"])) == ["m-d-y h:m", "d-m-y h:m", "y-m-d h:m", "ddMonyyyy h:m"]
+    @test names(readjmp("time.jmp", drop = [r"d"])) == ["h:m:s", "h:m", "Locale Date Time h:m", "Locale Date Time h:m:s"]
 end
 
 @testset "byte integers" begin


### PR DESCRIPTION
Rename keywords `include_columns` and `exclude_columns` to `select` and `drop`. Deprecate `include_columns` and `exclude_columns`.

Rationale: CSV.jl uses keywords `select` and `drop` https://csv.juliadata.org/stable/reading.html#select.